### PR TITLE
Remove hardcoded base62 length

### DIFF
--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -68,7 +68,7 @@ class Ksuid:
     def __str__(self) -> str:
         """Creates a base62 string representation"""
 
-        return base62.encode(int.from_bytes(bytes(self), "big")).zfill(27)
+        return base62.encode(int.from_bytes(bytes(self), "big")).zfill(self.BASE62_LENGTH)
 
     def __repr__(self) -> str:
         return str(self)


### PR DESCRIPTION
This PR removes the hardcoded base62 length, replacing it with the class property `BASE62_LENGTH`. This makes it easier/cleaner to subclass `Ksuid` to use, e.g., shorter payloads.

```
class KsuidShort(Ksuid):
    PAYLOAD_LENGTH_IN_BYTES = 8
    BYTES_LENGTH = TIMESTAMP_LENGTH_IN_BYTES + PAYLOAD_LENGTH_IN_BYTES
    BASE62_LENGTH = math.ceil(BYTES_LENGTH * 4 / 3)
```